### PR TITLE
Fix bug where the port number wasn't being read correctly

### DIFF
--- a/osxkeychain.go
+++ b/osxkeychain.go
@@ -308,13 +308,14 @@ func FindInternetPassword(pass *InternetPassword) (*InternetPassword, error) {
 		C.CFDictionaryGetValue(resultdict, unsafe.Pointer(C.kSecAttrAuthenticationType)),
 	))
 
-	// TODO: extract port number. The CFNumberRef in the dict doesn't appear to
-	// have a value.
-	// 	portref := (C.CFNumberRef)(C.CFDictionaryGetValue(dict, unsafe.Pointer(C.kSecAttrPort)))
-	// 	if portref != nil {
-	// 		var portval unsafe.Pointer
-	// 		portsuccess := C.CFNumberGetValue(portref, C.kCFNumberCharType, portval)
-	// 	}
+	portref := (C.CFNumberRef)(C.CFDictionaryGetValue(resultdict, unsafe.Pointer(C.kSecAttrPort)))
+	if portref != nil {
+		var port int32
+		portsuccess := C.CFNumberGetValue(portref, C.kCFNumberSInt32Type, unsafe.Pointer(&port))
+		if portsuccess == C.true {
+			resp.Port = int(port)
+		}
+	}
 
 	return &resp, nil
 }

--- a/osxkeychain.go
+++ b/osxkeychain.go
@@ -24,6 +24,7 @@ import (
 
 type ProtocolType C.SecProtocolType
 
+// TODO: Fill this out.
 const (
 	ProtocolHTTP  ProtocolType = C.kSecProtocolTypeHTTP
 	ProtocolHTTPS              = C.kSecProtocolTypeHTTPS
@@ -32,6 +33,7 @@ const (
 
 type AuthenticationType C.SecAuthenticationType
 
+// TODO: Fill this out.
 const (
 	AuthenticationHTTPBasic AuthenticationType = C.kSecAuthenticationTypeHTTPBasic
 	AuthenticationDefault                      = C.kSecAuthenticationTypeDefault
@@ -118,12 +120,8 @@ func (ke keychainError) Error() string {
 	return fmt.Sprintf("keychainError with unknown error code %d", C.OSStatus(ke))
 }
 
-func protocolTypeToGo(proto C.CFTypeRef) ProtocolType {
-	if proto == nil {
-		// handle nil?
-		fmt.Println("nil proto in protocolTypeToGo")
-		return ProtocolAny
-	}
+func protocolTypeFromRef(proto C.CFTypeRef) ProtocolType {
+	// TODO: Fill this out.
 	switch proto {
 	case C.kSecAttrProtocolHTTP:
 		return ProtocolHTTP
@@ -133,17 +131,15 @@ func protocolTypeToGo(proto C.CFTypeRef) ProtocolType {
 	panic(fmt.Sprintf("unknown proto in protocolTypeToGo: %v", proto))
 }
 
-func authenticationTypeToGo(authtype C.CFTypeRef) AuthenticationType {
-	if authtype == nil {
-		// handle nil?
-		fmt.Println("nil authtype in authenticationTypeToGo")
-		return AuthenticationAny
-	}
-	switch authtype {
+func authenticationTypeFromRef(authType C.CFTypeRef) AuthenticationType {
+	// TODO: Fill this out.
+	switch authType {
 	case C.kSecAttrAuthenticationTypeHTTPBasic:
 		return AuthenticationHTTPBasic
+	case C.kSecAttrAuthenticationTypeDefault:
+		return AuthenticationDefault
 	}
-	panic(fmt.Sprintf("unknown authtype in authenticationTypeToGo: %v", authtype))
+	panic(fmt.Sprintf("unknown authType in authenticationTypeFromStringRef: %v", authType))
 }
 
 // Adds an Internet password to the user's default keychain.
@@ -272,8 +268,8 @@ func FindInternetPassword(pass *InternetPassword) (*InternetPassword, error) {
 	resp.AccountName = getCFDictValueUTF8String(resultdict, C.kSecAttrAccount)
 	resp.Path = getCFDictValueUTF8String(resultdict, C.kSecAttrPath)
 	resp.Port = (int)(getCFDictValueInt32(resultdict, C.kSecAttrPort))
-	resp.Protocol = protocolTypeToGo(getCFDictValueRef(resultdict, C.kSecAttrProtocol))
-	resp.AuthType = authenticationTypeToGo(getCFDictValueRef(resultdict, C.kSecAttrAuthenticationType))
+	resp.Protocol = protocolTypeFromRef(getCFDictValueRef(resultdict, C.kSecAttrProtocol))
+	resp.AuthType = authenticationTypeFromRef(getCFDictValueRef(resultdict, C.kSecAttrAuthenticationType))
 
 	return &resp, nil
 }

--- a/osxkeychain.go
+++ b/osxkeychain.go
@@ -11,7 +11,6 @@ package osxkeychain
 #include <stdlib.h>
 #include <CoreFoundation/CoreFoundation.h>
 #include <Security/Security.h>
-#include "osxkeychain.h"
 */
 import "C"
 

--- a/osxkeychain.h
+++ b/osxkeychain.h
@@ -1,2 +1,0 @@
-CFDictionaryRef ItemCFDictionary(SecKeychainItemRef item);
-CFTypeRef* GetCFDictKeys(CFDictionaryRef dict);

--- a/osxkeychain_test.go
+++ b/osxkeychain_test.go
@@ -9,17 +9,17 @@ func TestInternetPassword(t *testing.T) {
 	accountNameVal := "bgentry"
 	serverNameVal := "go-osxkeychain-test.example.com"
 	securityDomainVal := ""
-	// 	portVal := 886
+	portVal := 886
 	pathVal := "/fake"
 	pass := InternetPassword{
 		ServerName:     serverNameVal,
 		SecurityDomain: securityDomainVal,
 		AccountName:    accountNameVal,
-		// 		Port:           portVal,
-		Path:     pathVal,
-		Protocol: ProtocolHTTPS,
-		AuthType: AuthenticationHTTPBasic,
-		Password: passwordVal,
+		Port:           portVal,
+		Path:           pathVal,
+		Protocol:       ProtocolHTTPS,
+		AuthType:       AuthenticationHTTPBasic,
+		Password:       passwordVal,
 	}
 	// Add the password
 	err := AddInternetPassword(&pass)
@@ -57,9 +57,9 @@ func TestInternetPassword(t *testing.T) {
 	if resp.Protocol != ProtocolHTTPS {
 		t.Errorf("FindInternetPassword expected Protocol=https, got %q", resp.Protocol)
 	}
-	// 	if resp.Port != portVal {
-	// 		t.Errorf("FindInternetPassword expected Port=%d, got %d", portVal, resp.Port)
-	// 	}
+	if resp.Port != portVal {
+		t.Errorf("FindInternetPassword expected Port=%d, got %d", portVal, resp.Port)
+	}
 	if resp.AuthType != AuthenticationHTTPBasic {
 		t.Errorf("FindInternetPassword expected AuthType=HTTPBasic, got %q", resp.AuthType)
 	}

--- a/osxkeychain_test.go
+++ b/osxkeychain_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestInternetPassword(t *testing.T) {
-	passwordVal := "longfakepassword with emoji 🍻 and \000 embedded nuls \000"
+	passwordVal := "longfakepassword with invalid UTF-8 \xc3\x28 and \000 embedded nuls \000"
 	accountNameVal := "bgentry"
 	serverNameVal := "go-osxkeychain-test.example.com"
 	securityDomainVal := ""


### PR DESCRIPTION
Also make the enum types match up with their C equivalents.

Also replace emoji in password test case with invalid UTF-8, since
passwords can be arbitrary bytes.
